### PR TITLE
Add demo with remote attestation verification

### DIFF
--- a/.enclavehub.yml
+++ b/.enclavehub.yml
@@ -1,6 +1,6 @@
 
 enclaves:
-  - name: sgx-hashmachine
+  - name: sgx-iot
     build:
       builder: docker
       build_kwargs:
@@ -8,8 +8,8 @@ enclaves:
         file: nix.Dockerfile
         target: export-stage
       output_dir: out
-      enclave_file: Enclave.so
-    enclave_config: Enclave/Enclave.config.xml
+      enclave_file: enclave.unsigned.so
+    enclave_config: enclave/enclave.config.xml
     #signed_enclave:
     #  path: .enclavehub/Enclave.signed.so
     #  mrenclave: a8a3094d76217c5dd0a1126ac142b36dd34f88514a99bf8dfc8ea852f1fa6238 

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,10 @@
+[flake8]
+max_line_length=80
+max_doc_length=89
+exclude =
+	charm/,
+	.eggs/,
+        apps/tutorial/
+ignore = E203, E266, E501, W503
+max-complexity = 45
+select = B,C,E,F,W,T4,B9

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+demo_sgx/

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y \
                 python3.9-dev \
                 python3-pip \
                 vim \
+                git \
         && rm -rf /var/lib/apt/lists/*
 
 # symlink python3.9 to python
@@ -61,7 +62,12 @@ RUN set -ex; \
 		\) -exec rm -rf '{}' +; \
 	rm -f get-pip.py
 
-RUN pip install cryptography ipython requests pyyaml
+RUN pip install cryptography ipython requests pyyaml ipdb
+RUN set -ex; \
+    \
+    cd /tmp; \
+    git clone --recurse-submodules https://github.com/sbellem/auditee.git; \
+    pip install auditee/
 
 WORKDIR /usr/src/sgxiot
 
@@ -81,3 +87,31 @@ ARG SGX_DEBUG=1
 ENV SGX_DEBUG $SGX_DEBUG
 
 RUN make just-app
+
+# docker cli
+RUN set -ex; \
+    \
+    apt-get update; \
+    apt-get install -y \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        gnupg \
+        lsb-release;
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
+        gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+
+RUN echo \
+    "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+RUN apt-get update && apt-get install -y docker-ce-cli
+
+# docker buildx
+#RUN set -ex; \
+#    \
+#    apt-get update && apt-get install -y curl; \
+#    mkdir -p ~/.docker/cli-plugins; \
+#    cd ~/.docker/cli-plugins; \
+#    curl -L https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.darwin-amd64 -o docker-buildx; \
+#    chmod a+x ~/.docker/cli-plugins/docker-buildx;

--- a/app/app.c
+++ b/app/app.c
@@ -13,11 +13,14 @@
 
 static struct option long_options[] = {
     {"keygen", no_argument, 0, 0},
+    {"quote", no_argument, 0, 0},
     {"sign", no_argument, 0, 0},
     {"enclave-path", required_argument, 0, 0},
-    {"statefile", required_argument, 0, 0},
+    {"sealedprivkey", required_argument, 0, 0},
+    {"sealedpubkey", required_argument, 0, 0},
     {"signature", required_argument, 0, 0},
     {"public-key", required_argument, 0, 0},
+    {"quotefile", required_argument, 0, 0},
     {0, 0, 0, 0}};
 
 /**
@@ -25,12 +28,15 @@ static struct option long_options[] = {
  */
 int main(int argc, char **argv) {
     bool opt_keygen = false;
+    bool opt_quote = false;
     bool opt_sign = false;
     const char *opt_enclave_path = NULL;
-    const char *opt_statefile = NULL;
+    const char *opt_sealedprivkey_file = NULL;
+    const char *opt_sealedpubkey_file = NULL;
     const char *opt_signature_file = NULL;
     const char *opt_input_file = NULL;
     const char *opt_public_key_file = NULL;
+    const char *opt_quote_file = NULL;
 
     int option_index = 0;
 
@@ -41,19 +47,28 @@ int main(int argc, char **argv) {
                 opt_keygen = true;
                 break;
             case 1:
-                opt_sign = true;
+                opt_quote = true;
                 break;
             case 2:
-                opt_enclave_path = optarg;
+                opt_sign = true;
                 break;
             case 3:
-                opt_statefile = optarg;
+                opt_enclave_path = optarg;
                 break;
             case 4:
-                opt_signature_file = optarg;
+                opt_sealedprivkey_file = optarg;
                 break;
             case 5:
+                opt_sealedpubkey_file = optarg;
+                break;
+            case 6:
+                opt_signature_file = optarg;
+                break;
+            case 7:
                 opt_public_key_file = optarg;
+                break;
+            case 8:
+                opt_quote_file = optarg;
                 break;
         }
     }
@@ -62,29 +77,43 @@ int main(int argc, char **argv) {
         opt_input_file = argv[optind++];
     }
 
-    if (!opt_keygen && !opt_sign) {
-        fprintf(stderr, "Error: Must specifiy either --keygen or --sign\n");
+    if (!opt_keygen && !opt_sign && !opt_quote) {
+        fprintf(
+            stderr,
+            "Error: Must specifiy either --keygen or --sign or --quotegen\n");
         return EXIT_FAILURE;
     }
 
-    if (opt_keygen &&
-        (!opt_enclave_path || !opt_statefile || !opt_public_key_file)) {
+    if (opt_keygen && (!opt_enclave_path || !opt_sealedprivkey_file ||
+                       !opt_sealedprivkey_file || !opt_public_key_file)) {
         fprintf(stderr, "Usage:\n");
         fprintf(stderr,
                 "  %s --keygen --enclave-path /path/to/enclave.signed.so "
-                "--statefile sealeddata.bin --public-key mykey.pem\n",
+                "--sealedprivkey sealedprivkey.bin "
+                "--sealedpubkey sealedpubkey.bin "
+                "--public-key mykey.pem\n",
                 argv[0]);
         return EXIT_FAILURE;
     }
 
-    if (opt_sign && (!opt_enclave_path || !opt_statefile ||
+    if (opt_quote &&
+        (!opt_enclave_path || !opt_sealedpubkey_file || !opt_quote_file)) {
+        fprintf(stderr, "Usage:\n");
+        fprintf(stderr,
+                "  %s --quotegen --enclave-path /path/to/enclave.signed.so "
+                "--sealedpubkey sealedpubkey.bin --quotefile quote.json\n",
+                argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    if (opt_sign && (!opt_enclave_path || !opt_sealedprivkey_file ||
                      !opt_signature_file || !opt_input_file)) {
         fprintf(stderr, "Usage:\n");
-        fprintf(
-            stderr,
-            "  %s --sign --enclave-path /path/to/enclave.signed.so --statefile "
-            "sealeddata.bin --signature inputfile.signature inputfile\n",
-            argv[0]);
+        fprintf(stderr,
+                "  %s --sign --enclave-path /path/to/enclave.signed.so "
+                "--sealedprivkey "
+                "sealeddata.bin --signature inputfile.signature inputfile\n",
+                argv[0]);
         return EXIT_FAILURE;
     }
 
@@ -92,17 +121,23 @@ int main(int argc, char **argv) {
 
     bool success_status =
         create_enclave(opt_enclave_path) && enclave_get_buffer_sizes() &&
-        allocate_buffers() &&
-        (opt_sign ? load_enclave_state(opt_statefile) : true) &&
-        (opt_keygen ? enclave_generate_key() : true) &&
+        allocate_buffers() && (opt_keygen ? enclave_generate_key() : true) &&
+        (opt_keygen
+             ? save_enclave_state(opt_sealedprivkey_file, opt_sealedpubkey_file)
+             : true) &&
+        // quote
+        (opt_quote ? load_sealedpubkey(opt_sealedpubkey_file) : true) &&
+        (opt_quote ? enclave_gen_quote() : true) &&
+        (opt_quote ? save_quote(opt_quote_file) : true) &&
+        //(opt_quote ? save_public_key(opt_public_key_file) : true) &&
+        // sign
+        (opt_sign ? load_enclave_state(opt_sealedprivkey_file) : true) &&
         (opt_sign ? load_input_file(opt_input_file) : true) &&
         (opt_sign ? enclave_sign_data() : true) &&
-        save_enclave_state(opt_statefile) &&
-        (opt_sign ? save_signature(opt_signature_file) : true) &&
-        (opt_keygen ? save_public_key(opt_public_key_file) : true);
+        // save_enclave_state(opt_sealedprivkey_file) &&
+        (opt_sign ? save_signature(opt_signature_file) : true);
     // TODO call function to generate report with public key in it
     //(opt_keygen ? enclave_generate_quote() : true);
-    //(opt_keygen ? save_public_key(opt_public_key_file) : true);
 
     if (sgx_lasterr != SGX_SUCCESS) {
         fprintf(stderr, "[GatewayApp]: ERROR: %s\n",

--- a/app/app.h
+++ b/app/app.h
@@ -12,6 +12,7 @@
 #include <sys/types.h>
 
 #include <openssl/bn.h>
+
 #include <sgx_quote.h>
 #include <sgx_uae_epid.h>
 #include <sgx_urts.h>
@@ -23,14 +24,20 @@ extern sgx_launch_token_t launch_token;
 extern int launch_token_updated;
 extern sgx_status_t sgx_lasterr;
 
-extern void *public_key_buffer;       /* unused for signing */
-extern size_t public_key_buffer_size; /* unused for signing */
-extern void *sealed_data_buffer;
-extern size_t sealed_data_buffer_size;
+extern void *public_key_buffer;          /* unused for signing */
+extern size_t public_key_buffer_size;    /* unused for signing */
+extern void *sealed_pubkey_buffer;       /* unused for signing */
+extern size_t sealed_pubkey_buffer_size; /* unused for signing */
+extern void *sealed_privkey_buffer;
+extern size_t sealed_privkey_buffer_size;
+extern void *quote_buffer;
+extern size_t quote_buffer_size;
 extern void *signature_buffer;
 extern size_t signature_buffer_size;
 extern void *input_buffer;
 extern size_t input_buffer_size;
+extern void *quote_buffer;
+extern size_t quote_buffer_size;
 
 /* Function prototypes */
 
@@ -49,6 +56,13 @@ bool read_file_into_memory(const char *const filename, void **buffer,
 
 bool load_enclave_state(const char *const statefile);
 
+bool load_sealed_data(const char *const sealed_data_file, void *buffer,
+                      size_t buffer_size);
+
+bool load_sealedprivkey(const char *const sealedprivkey_file);
+
+bool load_sealedpubkey(const char *const sealedpubkey_file);
+
 bool load_input_file(const char *const input_file);
 
 bool enclave_sign_data(void);
@@ -56,14 +70,20 @@ bool enclave_sign_data(void);
 bool enclave_generate_key(void);
 
 bool enclave_generate_quote(sgx_report_data_t report_data);
+bool enclave_gen_quote();
 
-bool save_enclave_state(const char *const statefile);
+// bool save_enclave_state(const char *const statefile);
+bool save_enclave_state(const char *const sealedprivkey_file,
+                        const char *const sealedpubkey_file);
+bool save_state(const char *const statefile, void *buffer, size_t buffer_size);
 
 BIGNUM *bignum_from_little_endian_bytes_32(const unsigned char *const bytes);
 
 bool save_signature(const char *const signature_file);
 
 bool save_public_key(const char *const public_key_file);
+
+bool save_quote(const char *const quote_file);
 
 void destroy_enclave(void);
 

--- a/app/buffers.c
+++ b/app/buffers.c
@@ -9,46 +9,52 @@
 
 #include "app.h"
 
-bool allocate_buffers()
-{
+bool allocate_buffers() {
     printf("[GatewayApp]: Allocating buffers\n");
-    sealed_data_buffer = calloc(sealed_data_buffer_size, 1);
+    sealed_privkey_buffer = calloc(sealed_privkey_buffer_size, 1);
     public_key_buffer = calloc(public_key_buffer_size, 1);
+    sealed_pubkey_buffer = calloc(sealed_pubkey_buffer_size, 1);
     signature_buffer = calloc(signature_buffer_size, 1);
 
-    if (sealed_data_buffer == NULL || public_key_buffer == NULL || signature_buffer == NULL)
-    {
-        fprintf(stderr, "[GatewayApp]: allocate_buffers() memory allocation failure\n");
+    if (sealed_privkey_buffer == NULL || sealed_pubkey_buffer == NULL ||
+        signature_buffer == NULL || public_key_buffer == NULL) {
+        fprintf(stderr,
+                "[GatewayApp]: allocate_buffers() memory allocation failure\n");
         sgx_lasterr = SGX_ERROR_UNEXPECTED;
     }
 
     return (sgx_lasterr == SGX_SUCCESS);
 }
 
-void cleanup_buffers()
-{
+void cleanup_buffers() {
     printf("[GatewayApp]: Deallocating buffers\n");
 
-    if (sealed_data_buffer != NULL)
-    {
-        free(sealed_data_buffer);
-        sealed_data_buffer = NULL;
+    if (sealed_privkey_buffer != NULL) {
+        free(sealed_privkey_buffer);
+        sealed_privkey_buffer = NULL;
     }
 
-    if (public_key_buffer != NULL)
-    {
+    if (sealed_pubkey_buffer != NULL) {
+        free(sealed_pubkey_buffer);
+        sealed_pubkey_buffer = NULL;
+    }
+
+    if (public_key_buffer != NULL) {
         free(public_key_buffer);
         public_key_buffer = NULL;
     }
 
-    if (signature_buffer != NULL)
-    {
+    if (signature_buffer != NULL) {
         free(signature_buffer);
         signature_buffer = NULL;
     }
 
-    if (input_buffer != NULL)
-    {
+    if (quote_buffer != NULL) {
+        free(quote_buffer);
+        quote_buffer = NULL;
+    }
+
+    if (input_buffer != NULL) {
         free(input_buffer);
         input_buffer = NULL;
     }

--- a/app/ecall_buffer.c
+++ b/app/ecall_buffer.c
@@ -10,25 +10,24 @@
 
 #include "app.h"
 
-bool enclave_get_buffer_sizes()
-{
+bool enclave_get_buffer_sizes() {
     sgx_status_t ecall_retval = SGX_SUCCESS;
 
     printf("[GatewayApp]: Querying enclave for buffer sizes\n");
 
     /*
-    * Invoke ECALL, 'ecall_calc_buffer_sizes()', to calculate the sizes of buffers needed for the untrusted app to store
-    * data (public key, sealed private key and signature) from the enclave.
-    */
-    sgx_lasterr = ecall_calc_buffer_sizes(enclave_id,
-                                                   &ecall_retval,
-                                                   &public_key_buffer_size,
-                                                   &sealed_data_buffer_size,
-                                                   &signature_buffer_size);
-    if (sgx_lasterr == SGX_SUCCESS &&
-        (ecall_retval != 0))
-    {
-        fprintf(stderr, "[GatewayApp]: ERROR: ecall_calc_buffer_sizes returned %d\n", ecall_retval);
+     * Invoke ECALL, 'ecall_calc_buffer_sizes()', to calculate the sizes of
+     * buffers needed for the untrusted app to store data (public key, sealed
+     * private key and signature) from the enclave.
+     */
+    sgx_lasterr = ecall_calc_buffer_sizes(
+        enclave_id, &ecall_retval, &public_key_buffer_size,
+        &sealed_pubkey_buffer_size, &sealed_privkey_buffer_size,
+        &signature_buffer_size);
+    if (sgx_lasterr == SGX_SUCCESS && (ecall_retval != 0)) {
+        fprintf(stderr,
+                "[GatewayApp]: ERROR: ecall_calc_buffer_sizes returned %d\n",
+                ecall_retval);
         sgx_lasterr = SGX_ERROR_UNEXPECTED;
     }
 

--- a/app/enclave_state.c
+++ b/app/enclave_state.c
@@ -9,48 +9,145 @@
 
 #include "app.h"
 
-
-bool load_enclave_state(const char *const statefile)
-{
-    void* new_buffer;
+bool load_enclave_state(const char *const statefile) {
+    void *new_buffer;
     size_t new_buffer_size;
 
     printf("[GatewayApp]: Loading enclave state\n");
 
-    bool ret_status = read_file_into_memory(statefile, &new_buffer, &new_buffer_size);
+    bool ret_status =
+        read_file_into_memory(statefile, &new_buffer, &new_buffer_size);
 
-    /* If we previously allocated a buffer, free it before putting new one in its place */
-    if (sealed_data_buffer != NULL)
-    {
-        free(sealed_data_buffer);
-        sealed_data_buffer = NULL;
+    /* If we previously allocated a buffer, free it before putting new one in
+     * its place */
+    if (sealed_privkey_buffer != NULL) {
+        free(sealed_privkey_buffer);
+        sealed_privkey_buffer = NULL;
     }
 
     /* Put new buffer into context */
-    sealed_data_buffer = new_buffer;
-    sealed_data_buffer_size = new_buffer_size;
+    sealed_privkey_buffer = new_buffer;
+    sealed_privkey_buffer_size = new_buffer_size;
 
     return ret_status;
 }
 
-bool save_enclave_state(const char *const statefile)
-{
+bool load_sealed_data(const char *const sealed_data_file, void *buffer,
+                      size_t buffer_size) {
+    void *new_buffer;
+    size_t new_buffer_size;
+
+    bool ret_status =
+        read_file_into_memory(sealed_data_file, &new_buffer, &new_buffer_size);
+
+    /* If we previously allocated a buffer, free it before putting new one in
+     * its place */
+    if (buffer != NULL) {
+        free(buffer);
+        buffer = NULL;
+    }
+
+    /* Put new buffer into context */
+    buffer = new_buffer;
+    buffer_size = new_buffer_size;
+
+    return ret_status;
+}
+
+bool load_sealedpubkey(const char *const sealedpubkey_file) {
+    printf("[GatewayApp]: Loading sealed public key\n");
+    // bool ret_status = load_sealed_data(sealedpubkey_file,
+    // sealed_pubkey_buffer,
+    //                                   sealed_pubkey_buffer_size);
+    // return ret_status;
+    void *new_buffer;
+    size_t new_buffer_size;
+
+    bool ret_status =
+        read_file_into_memory(sealedpubkey_file, &new_buffer, &new_buffer_size);
+
+    /* If we previously allocated a buffer, free it before putting new one in
+     * its place */
+    if (sealed_pubkey_buffer != NULL) {
+        free(sealed_pubkey_buffer);
+        sealed_pubkey_buffer = NULL;
+    }
+
+    /* Put new buffer into context */
+    sealed_pubkey_buffer = new_buffer;
+    sealed_pubkey_buffer_size = new_buffer_size;
+
+    return ret_status;
+}
+
+bool save_enclave_state(const char *const sealedprivkey_file,
+                        const char *const sealedpubkey_file) {
+    // bool ret_status = true;
+    // ret_status = save_state(sealedprivkey_file, sealed_privkey_buffer,
+    //                        sealed_privkey_buffer_size);
+    // ret_status = save_state(sealedpubkey_file, sealed_pubkey_buffer,
+    //                        sealed_pubkey_buffer_size);
+    // return ret_status;
+    bool ret_status = true;
+
+    printf("[GatewayApp]: Saving enclave state - sealed priv key\n");
+
+    FILE *sk_file = open_file(sealedprivkey_file, "wb");
+
+    if (sk_file == NULL) {
+        fprintf(stderr, "[GatewayApp]: save_enclave_state() fopen failed\n");
+        sgx_lasterr = SGX_ERROR_UNEXPECTED;
+        return false;
+    }
+
+    if (fwrite(sealed_privkey_buffer, sealed_privkey_buffer_size, 1, sk_file) !=
+        1) {
+        fprintf(stderr,
+                "[GatewayApp]: Enclave state only partially written.\n");
+        sgx_lasterr = SGX_ERROR_UNEXPECTED;
+        ret_status = false;
+    }
+
+    fclose(sk_file);
+
+    printf("[GatewayApp]: Saving enclave state - sealed pub key\n");
+
+    FILE *file = open_file(sealedpubkey_file, "wb");
+
+    if (file == NULL) {
+        fprintf(stderr, "[GatewayApp]: save_enclave_state() fopen failed\n");
+        sgx_lasterr = SGX_ERROR_UNEXPECTED;
+        return false;
+    }
+
+    if (fwrite(sealed_pubkey_buffer, sealed_pubkey_buffer_size, 1, file) != 1) {
+        fprintf(stderr,
+                "[GatewayApp]: Enclave state only partially written.\n");
+        sgx_lasterr = SGX_ERROR_UNEXPECTED;
+        ret_status = false;
+    }
+
+    fclose(file);
+
+    return ret_status;
+}
+
+bool save_state(const char *const statefile, void *buffer, size_t buffer_size) {
     bool ret_status = true;
 
     printf("[GatewayApp]: Saving enclave state\n");
 
     FILE *file = open_file(statefile, "wb");
 
-    if (file == NULL)
-    {
+    if (file == NULL) {
         fprintf(stderr, "[GatewayApp]: save_enclave_state() fopen failed\n");
         sgx_lasterr = SGX_ERROR_UNEXPECTED;
         return false;
     }
 
-    if (fwrite(sealed_data_buffer, sealed_data_buffer_size, 1, file) != 1)
-    {
-        fprintf(stderr, "[GatewayApp]: Enclave state only partially written.\n");
+    if (fwrite(buffer, buffer_size, 1, file) != 1) {
+        fprintf(stderr,
+                "[GatewayApp]: Enclave state only partially written.\n");
         sgx_lasterr = SGX_ERROR_UNEXPECTED;
         ret_status = false;
     }

--- a/app/globals.c
+++ b/app/globals.c
@@ -15,9 +15,13 @@ sgx_status_t sgx_lasterr;
 
 void *public_key_buffer;
 size_t public_key_buffer_size;
-void *sealed_data_buffer;
-size_t sealed_data_buffer_size;
+void *sealed_pubkey_buffer;
+size_t sealed_pubkey_buffer_size;
+void *sealed_privkey_buffer;
+size_t sealed_privkey_buffer_size;
 void *signature_buffer;
 size_t signature_buffer_size;
 void *input_buffer;
 size_t input_buffer_size;
+void *quote_buffer;
+size_t quote_buffer_size;

--- a/app/makefile
+++ b/app/makefile
@@ -21,7 +21,8 @@ all: ../interface/libenclave_stub_u.a app
 
 ../interface/libenclave_stub_u.a: ../interface/enclave.edl
 
-app: app.o globals.o ocall_print_string.o decode_sgx_status.o enclave.o buffers.o enclave_state.o endianswap.o readfile.o ecall_buffer.o keygen.o sign.o open_file.o hexutil.o base64.o
+app: app.o globals.o ocall_print_string.o decode_sgx_status.o enclave.o buffers.o enclave_state.o endianswap.o readfile.o ecall_buffer.o keygen.o sign.o open_file.o hexutil.o base64.o quote.o
+#ocall_print_int.o
 
 clean:
 	rm -f ../interface/*_u.* app *.o

--- a/app/ocall_print_string.c
+++ b/app/ocall_print_string.c
@@ -6,13 +6,19 @@
 
 #include <stdio.h>
 
-/* Ensure that ocall_print_string has exern C linkage */
+/* Ensure that ocall_print_string has extern C linkage */
 #include <enclave_u.h>
 
-void ocall_print_string(const char *str)
-{
-  /* Proxy/Bridge will check the length and null-terminate
-   * the input string to prevent buffer overflow.
-   */
-  printf("%s", str);
+void ocall_print_string(const char *str) {
+    /* Proxy/Bridge will check the length and null-terminate
+     * the input string to prevent buffer overflow.
+     */
+    printf("%s", str);
 }
+
+// void ocall_print_int(const int num) {
+//    /* Proxy/Bridge will check the length and null-terminate
+//     * the input string to prevent buffer overflow.
+//     */
+//    printf("%d", num);
+//}

--- a/app/quote.c
+++ b/app/quote.c
@@ -1,0 +1,155 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <enclave_u.h> /* For sgx_enclave_id_t */
+
+#include <sgx_quote.h>
+
+#include "app.h"
+
+bool enclave_gen_quote() {
+    printf("[GatewayApp]: Calling enclave to generate report\n");
+
+    sgx_status_t ecall_retval = SGX_ERROR_UNEXPECTED;
+    sgx_report_t report;
+    sgx_spid_t spid;
+    sgx_target_info_t target_info;
+    sgx_epid_group_id_t epid_gid;
+    sgx_status_t status;
+
+    /* Init Quote */
+    status = sgx_init_quote(&target_info, &epid_gid);
+
+    /*
+     * Invoke ECALL, 'ecall_unseal_and_quote()', to generate a quote including
+     * the sealed public key in the report data field.
+     */
+    memset(&report, 0, sizeof(report));
+    sgx_lasterr = ecall_unseal_and_quote(
+        enclave_id, &ecall_retval, &report, &target_info,
+        (char *)sealed_pubkey_buffer, sealed_pubkey_buffer_size,
+        (char *)public_key_buffer, public_key_buffer_size);
+
+    if (sgx_lasterr == SGX_SUCCESS && (ecall_retval != 0)) {
+        fprintf(stderr,
+                "[GatewayApp]: ERROR: ecall_unseal_and_quote returned %d\n",
+                ecall_retval);
+        sgx_lasterr = SGX_ERROR_UNEXPECTED;
+    }
+
+    // DEBUG Print pub key big endian form
+    /* ----- ----- ----- ----- experiment ----- ----- ----- ----- */
+    if (public_key_buffer_size != 64) {
+        fprintf(stderr,
+                "[GatewayApp]: assertion failed: key_buffer_size == 64\n");
+        return false;
+    }
+    BIGNUM *bn_x =
+        bignum_from_little_endian_bytes_32((uint8_t *)public_key_buffer);
+    BIGNUM *bn_y =
+        bignum_from_little_endian_bytes_32((uint8_t *)public_key_buffer + 32);
+
+    printf("\nbn_x dec: %s\n", BN_bn2dec(bn_x));
+    printf("bn_y dec: %s\n\n", BN_bn2dec(bn_y));
+    printf("bn_x hex: %s\n", BN_bn2hex(bn_x));
+    printf("bn_y hex: %s\n\n", BN_bn2hex(bn_y));
+    /* ----- ----- ----- ----- experiment ----- ----- ----- ----- */
+
+    // calculate quote size
+    sgx_quote_t *quote;
+    uint32_t quote_size = 0;
+
+    printf("[GatewayApp]: Call sgx_calc_quote_size() ...\n");
+    status = sgx_calc_quote_size(NULL, 0, &quote_size);
+    if (status != SGX_SUCCESS) {
+        fprintf(stderr, "SGX error while getting quote size: %08x\n", status);
+        return 1;
+    }
+
+    quote = (sgx_quote_t *)malloc(quote_size);
+    if (quote == NULL) {
+        fprintf(stderr, "out of memory\n");
+        return 1;
+    }
+    memset(quote, 0, quote_size);
+
+    // get quote
+    sgx_quote_sign_type_t linkable = SGX_UNLINKABLE_SIGNATURE;
+
+    printf("[GatewayApp]: SPID: %s\n", getenv("SGX_SPID"));
+    from_hexstring((unsigned char *)&spid, (unsigned char *)getenv("SGX_SPID"),
+                   16);
+    printf("[GatewayApp]: Call sgx_get_quote() ...\n");
+    status = sgx_get_quote(&report, linkable, &spid, NULL, NULL, 0, NULL, quote,
+                           quote_size);
+    fprintf(stdout, "[GatewayApp]: status of sgx_get_quote(): %08x\n", status);
+    printf("[GatewayApp]: status of sgx_get_quote(): %s\n",
+           status == SGX_SUCCESS ? "success" : "error");
+    if (status != SGX_SUCCESS) {
+        fprintf(stderr, "[GatewayApp]: sgx_get_quote: %08x\n", status);
+        return 1;
+    }
+
+    // copy quote and quote_size into globals
+    memcpy(&quote_buffer, &quote, quote_size);
+    memcpy(&quote_buffer_size, &quote_size, sizeof(quote_size));
+
+    printf("\n[GatewayApp]: MRENCLAVE: \t");
+    print_hexstring(stdout, &quote->report_body.mr_enclave,
+                    sizeof(sgx_measurement_t));
+    printf("\n[GatewayApp]: MRSIGNER: \t");
+    print_hexstring(stdout, &quote->report_body.mr_signer,
+                    sizeof(sgx_measurement_t));
+    printf("\n[GatewayApp]: Report Data: \t");
+    print_hexstring(stdout, &quote->report_body.report_data,
+                    sizeof(sgx_report_data_t));
+    printf("\n\n");
+
+    char *b64quote = NULL;
+    b64quote = base64_encode((char *)quote, quote_size);
+    if (b64quote == NULL) {
+        printf("Could not base64 encode quote\n");
+        return 1;
+    }
+
+    printf("Quote, ready to be sent to IAS (POST /attestation/v4/report):\n");
+    printf("{\n");
+    printf("\t\"isvEnclaveQuote\":\"%s\"", b64quote);
+    // if (OPT_ISSET(flags, OPT_NONCE)) {
+    //    printf(",\n\t\"nonce\":\"");
+    //    print_hexstring(stdout, &config->nonce, 16);
+    //    printf("\"");
+    //}
+
+    printf("\n}\n\n");
+    printf(
+        "See "
+        "https://api.trustedservices.intel.com/documents/"
+        "sgx-attestation-api-spec.pdf\n");
+
+    return (sgx_lasterr == SGX_SUCCESS);
+}
+
+bool save_quote(const char *const quote_file) {
+    bool ret_status = true;
+
+    printf("[GatewayApp]: Saving quote\n");
+
+    FILE *fquote = open_file(quote_file, "wb");
+
+    if (fquote == NULL) {
+        fprintf(stderr, "[GatewayApp]: save_quote() fopen failed\n");
+        sgx_lasterr = SGX_ERROR_UNEXPECTED;
+        return false;
+    }
+
+    if (fwrite((char *)quote_buffer, quote_buffer_size, 1, fquote) != 1) {
+        fprintf(stderr, "[GatewayApp]: Quote only partially written.\n");
+        sgx_lasterr = SGX_ERROR_UNEXPECTED;
+        ret_status = false;
+    }
+
+    fclose(fquote);
+
+    return ret_status;
+}

--- a/app/sign.c
+++ b/app/sign.c
@@ -9,49 +9,44 @@
 
 #include <enclave_u.h> /* For sgx_enclave_id_t */
 
-#include <openssl/obj_mac.h>
-#include <openssl/ec.h>
 #include <openssl/bn.h>
+#include <openssl/ec.h>
+#include <openssl/obj_mac.h>
 #include <openssl/pem.h>
 
 #include "app.h"
 
-bool load_input_file(const char *const input_file)
-{
+bool load_input_file(const char *const input_file) {
     printf("[GatewayApp]: Loading input file\n");
 
     return read_file_into_memory(input_file, &input_buffer, &input_buffer_size);
 }
 
-bool enclave_sign_data()
-{
+bool enclave_sign_data() {
     sgx_status_t ecall_retval = SGX_ERROR_UNEXPECTED;
 
     printf("[GatewayApp]: Calling enclave to generate key material\n");
 
     /*
-    * Invoke ECALL, 'ecall_unseal_and_sign()', to sign some data with the sealed key
-    */
-    sgx_lasterr = ecall_unseal_and_sign(enclave_id,
-                                        &ecall_retval,
-                                        (uint8_t *)input_buffer,
-                                        (uint32_t)input_buffer_size,
-                                        (char *)sealed_data_buffer,
-                                        sealed_data_buffer_size,
-                                        (char *)signature_buffer,
-                                        signature_buffer_size);
-    if (sgx_lasterr == SGX_SUCCESS &&
-        (ecall_retval != 0))
-    {
-        fprintf(stderr, "[GatewayApp]: ERROR: ecall_unseal_and_sign returned %d\n", ecall_retval);
+     * Invoke ECALL, 'ecall_unseal_and_sign()', to sign some data with the
+     * sealed key
+     */
+    sgx_lasterr = ecall_unseal_and_sign(
+        enclave_id, &ecall_retval, (uint8_t *)input_buffer,
+        (uint32_t)input_buffer_size, (char *)sealed_privkey_buffer,
+        sealed_privkey_buffer_size, (char *)signature_buffer,
+        signature_buffer_size);
+    if (sgx_lasterr == SGX_SUCCESS && (ecall_retval != 0)) {
+        fprintf(stderr,
+                "[GatewayApp]: ERROR: ecall_unseal_and_sign returned %d\n",
+                ecall_retval);
         sgx_lasterr = SGX_ERROR_UNEXPECTED;
     }
 
     return (sgx_lasterr == SGX_SUCCESS);
 }
 
-bool save_signature(const char *const signature_file)
-{
+bool save_signature(const char *const signature_file) {
     bool ret_status = true;
     ECDSA_SIG *ecdsa_sig = NULL;
     BIGNUM *r = NULL, *s = NULL;
@@ -60,54 +55,50 @@ bool save_signature(const char *const signature_file)
     int sig_len = 0;
     int sig_len2 = 0;
 
-    if (signature_buffer_size != 64)
-    {
-        fprintf(stderr, "[GatewayApp]: assertion failed: signature_buffer_size == 64\n");
+    if (signature_buffer_size != 64) {
+        fprintf(
+            stderr,
+            "[GatewayApp]: assertion failed: signature_buffer_size == 64\n");
         ret_status = false;
         goto cleanup;
     }
 
     ecdsa_sig = ECDSA_SIG_new();
-    if (ecdsa_sig == NULL)
-    {
+    if (ecdsa_sig == NULL) {
         fprintf(stderr, "[GatewayApp]: memory alloction failure ecdsa_sig\n");
         ret_status = false;
         goto cleanup;
     }
 
     r = bignum_from_little_endian_bytes_32((unsigned char *)signature_buffer);
-    s = bignum_from_little_endian_bytes_32((unsigned char *)signature_buffer + 32);
-    if (!ECDSA_SIG_set0(ecdsa_sig, r, s))
-    {
+    s = bignum_from_little_endian_bytes_32((unsigned char *)signature_buffer +
+                                           32);
+    if (!ECDSA_SIG_set0(ecdsa_sig, r, s)) {
         ret_status = false;
         goto cleanup;
     }
 
     sig_len = i2d_ECDSA_SIG(ecdsa_sig, NULL);
-    if (sig_len <= 0)
-    {
+    if (sig_len <= 0) {
         ret_status = false;
         goto cleanup;
     }
 
     sig_len2 = i2d_ECDSA_SIG(ecdsa_sig, &sig_buffer);
-    if (sig_len != sig_len2)
-    {
+    if (sig_len != sig_len2) {
         ret_status = false;
         goto cleanup;
     }
 
     file = open_file(signature_file, "wb");
-    if (file == NULL)
-    {
+    if (file == NULL) {
         fprintf(stderr, "[GatewayApp]: save_signature() fopen failed\n");
         sgx_lasterr = SGX_ERROR_UNEXPECTED;
         ret_status = false;
         goto cleanup;
     }
 
-    if (fwrite(sig_buffer, (size_t)sig_len, 1, file) != 1)
-    {
+    if (fwrite(sig_buffer, (size_t)sig_len, 1, file) != 1) {
         fprintf(stderr, "GatewayApp]: ERROR: Could not write signature\n");
         sgx_lasterr = SGX_ERROR_UNEXPECTED;
         ret_status = false;
@@ -115,18 +106,45 @@ bool save_signature(const char *const signature_file)
     }
 
 cleanup:
-    if (file != NULL)
-    {
+    if (file != NULL) {
         fclose(file);
     }
-    if (ecdsa_sig)
-    {
+    if (ecdsa_sig) {
         ECDSA_SIG_free(ecdsa_sig); /* Above will also free r and s */
     }
-    if (sig_buffer)
-    {
+    if (sig_buffer) {
         free(sig_buffer);
     }
 
     return ret_status;
 }
+
+// quote.c
+// bool enclave_gen_quote() {
+//    sgx_status_t ecall_retval = SGX_ERROR_UNEXPECTED;
+//    sgx_spid_t spid;
+//
+//    printf("[GatewayApp]: Calling enclave to generate quote\n");
+//    printf("[GatewayApp]: SPID: %s\n", getenv("SGX_SPID"));
+//    from_hexstring((unsigned char *)&spid, (unsigned char
+//    *)getenv("SGX_SPID"),
+//                   16);
+//
+//    /*
+//     * Invoke ECALL, 'ecall_unseal_and_quote()', to generate a quote including
+//     * the sealed public key in the report data field.
+//     */
+//    sgx_lasterr = ecall_unseal_and_quote(enclave_id, &ecall_retval,
+//                                         (char *)sealed_pubkey_buffer,
+//                                         //(char *)sealed_privkey_buffer,
+//                                         // sealed_privkey_buffer_size);
+//                                         sealed_pubkey_buffer_size, spid);
+//    if (sgx_lasterr == SGX_SUCCESS && (ecall_retval != 0)) {
+//        fprintf(stderr,
+//                "[GatewayApp]: ERROR: ecall_unseal_and_quote returned %d\n",
+//                ecall_retval);
+//        sgx_lasterr = SGX_ERROR_UNEXPECTED;
+//    }
+//
+//    return (sgx_lasterr == SGX_SUCCESS);
+//}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,9 +31,18 @@ services:
     environment:
       SGX_SPID: ${SGX_SPID}
       IAS_PRIMARY_KEY: ${IAS_PRIMARY_KEY}
+      PYTHONBREAKPOINT: ipdb.set_trace
     volumes:
       - aesmd-socket:/var/run/aesmd
-    command: ./run_demo_sgx.sh
+      - ./demo_sgx:/usr/src/sgxiot/demo_sgx
+      - ./.enclavehub.yml:/usr/src/sgxiot/.enclavehub.yml
+      - ./enclave.nix:/usr/src/sgxiot/enclave.nix
+      - ./verifysig.py:/usr/src/sgxiot/verifysig.py
+      - ./run_keygen.sh:/usr/src/sgxiot/run_keygen.sh
+      - ./run_quote.sh:/usr/src/sgxiot/run_quote.sh
+      - /var/run/docker.sock:/var/run/docker.sock
+    #command: ./run_demo_sgx.sh
+    command: ./run_quote.sh
 
 volumes:
   aesmd-socket:

--- a/enclave.nix
+++ b/enclave.nix
@@ -8,17 +8,17 @@ pkgs.stdenv.mkDerivation {
   name = "sgx-iot";
   # FIXME not sure why but the build is non-deterministic if using src = ./.;
   # Possibly some untracked file(s) causing the problem ...?
-  src = ./.;
+  #src = ./.;
   # NOTE The commit (rev) cannot include this file, and therefore will at the very
   # best one commit behind the commit including this file.
-  #src = pkgs.fetchFromGitHub {
-  #  owner = "sbellem";
-  #  repo = "sgx-iot";
-  #  rev = "d357650fad44c646e30b9049cbc1d4ddbbf47313";
-  #  # Command to get the sha256 hash (note the --fetch-submodules arg):
-  #  # nix run -f '<nixpkgs>' nix-prefetch-github -c nix-prefetch-github --rev d357650fad44c646e30b9049cbc1d4ddbbf47313 sbellem sgx-iot
-  #  sha256 = "1mpvr6g1dly2bkph57lwk2kn36yddfp614pq2l6w9ap94dp0siiw";
-  #};
+  src = pkgs.fetchFromGitHub {
+    owner = "sbellem";
+    repo = "sgx-iot";
+    rev = "9c3e06b4f5507642ebd3730e076dc4170b16c41c";
+    # Command to get the sha256 hash (note the --fetch-submodules arg):
+    # nix run -f '<nixpkgs>' nix-prefetch-github -c nix-prefetch-github --rev 9c3e06b4f5507642ebd3730e076dc4170b16c41c sbellem sgx-iot
+    sha256 = "0lnkj1h7cv4zzfwnmkfib7cpyqvgw1l2p9hjr2598i6mrngqn80l";
+  };
   preConfigure = ''
     export SGX_SDK=$sgxsdk/sgxsdk
     export PATH=$PATH:$SGX_SDK/bin:$SGX_SDK/bin/x64

--- a/enclave/calcbuffsize.c
+++ b/enclave/calcbuffsize.c
@@ -11,26 +11,34 @@
 #include "enclave.h"
 
 #include <sgx_tcrypto.h>
-#include <sgx_utils.h>
 #include <sgx_tseal.h>
+#include <sgx_utils.h>
 
 /**
- * This function calculates the sizes of buffers needed for the untrusted app to store
- * data (public key, sealed private key and signature) from the enclave.
+ * This function calculates the sizes of buffers needed for the untrusted app to
+ * store data (public key, sealed private key and signature) from the enclave.
  *
  * @param epubkey_size            Output parameter for size of public key.
- * @param esealedprivkey_size     Output parameter for size of sealed private key.
+ * @param esealedprivkey_size     Output parameter for size of sealed private
+ * key.
  * @param esignature_size         Output parameter for size of signature.
  *
- * @return                        SGX_SUCCESS (Error code = 0x0000) on success, some
- *                                other appropriate sgx_status_t value upon failure.
+ * @return                        SGX_SUCCESS (Error code = 0x0000) on success,
+ * some other appropriate sgx_status_t value upon failure.
  */
 
-sgx_status_t ecall_calc_buffer_sizes(size_t* epubkey_size, size_t* esealedprivkey_size, size_t* esignature_size)
-{
-  *epubkey_size = sizeof(sgx_ec256_public_t);
-  *esealedprivkey_size = sgx_calc_sealed_data_size(0U, sizeof(sgx_ec256_private_t));
-  *esignature_size = sizeof(sgx_ec256_signature_t);
-  print("\nTrustedApp: Sizes for public key, sealed private key and signature calculated successfully.\n");
-  return SGX_SUCCESS;
+sgx_status_t ecall_calc_buffer_sizes(size_t* epubkey_size,
+                                     size_t* esealedpubkey_size,
+                                     size_t* esealedprivkey_size,
+                                     size_t* esignature_size) {
+    *epubkey_size = sizeof(sgx_ec256_public_t);
+    *esealedpubkey_size =
+        sgx_calc_sealed_data_size(0U, sizeof(sgx_ec256_public_t));
+    *esealedprivkey_size =
+        sgx_calc_sealed_data_size(0U, sizeof(sgx_ec256_private_t));
+    *esignature_size = sizeof(sgx_ec256_signature_t);
+    print(
+        "\nTrustedApp: Sizes for sealed public key, sealed private key and "
+        "signature calculated successfully.\n");
+    return SGX_SUCCESS;
 }

--- a/enclave/keygen.c
+++ b/enclave/keygen.c
@@ -12,7 +12,6 @@
 
 #include <sgx_quote.h>
 #include <sgx_tcrypto.h>
-//#include <sgx_tkey_exchange.h>
 #include <sgx_tseal.h>
 #include <sgx_utils.h>
 
@@ -70,6 +69,79 @@ sgx_status_t ecall_key_gen_and_seal(char *pubkey, size_t pubkey_size,
     print(
         "\nTrustedApp: Key pair generated and private key was sealed. Sent the "
         "public key and sealed private key back.\n");
+    ret = SGX_SUCCESS;
+
+cleanup:
+    // Step 4: Close Context.
+    if (p_ecc_handle != NULL) {
+        sgx_ecc256_close_context(p_ecc_handle);
+    }
+
+    return ret;
+}
+
+sgx_status_t ecall_key_gen_and_seal_all(char *sealedpubkey,
+                                        size_t sealedpubkey_size,
+                                        char *sealedprivkey,
+                                        size_t sealedprivkey_size) {
+    // Step 1: Open Context.
+    sgx_status_t ret = SGX_ERROR_UNEXPECTED;
+    sgx_ecc_state_handle_t p_ecc_handle = NULL;
+
+    if ((ret = sgx_ecc256_open_context(&p_ecc_handle)) != SGX_SUCCESS) {
+        print("\n[[TrustedApp]]: sgx_ecc256_open_context() failed !\n");
+        goto cleanup;
+    }
+
+    // Step 2: Create Key Pair.
+    sgx_ec256_private_t p_private;
+    sgx_ec256_public_t p_public;
+    if ((ret = sgx_ecc256_create_key_pair(&p_private, &p_public,
+                                          p_ecc_handle)) != SGX_SUCCESS) {
+        print("\n[[TrustedApp]]: sgx_ecc256_create_key_pair() failed !\n");
+        goto cleanup;
+    }
+
+    // Step 3.1: Calculate sealed private key data size.
+    if (sealedprivkey_size >=
+        sgx_calc_sealed_data_size(0U, sizeof(p_private))) {
+        if ((ret = sgx_seal_data(
+                 0U, NULL, sizeof(p_private), (uint8_t *)&p_private,
+                 (uint32_t)sealedprivkey_size,
+                 (sgx_sealed_data_t *)sealedprivkey)) != SGX_SUCCESS) {
+            print("\nTrustedApp: sgx_seal_data() failed !\n");
+            goto cleanup;
+        }
+    } else {
+        print(
+            "\n[[TrustedApp]]: Size allocated for sealedprivkey by untrusted "
+            "app "
+            "is less than the required size !\n");
+        ret = SGX_ERROR_INVALID_PARAMETER;
+        goto cleanup;
+    }
+
+    // Step 3.2: Calculate sealed public key data size.
+    if (sealedpubkey_size >= sgx_calc_sealed_data_size(0U, sizeof(p_public))) {
+        if ((ret = sgx_seal_data(
+                 0U, NULL, sizeof(p_public), (uint8_t *)&p_public,
+                 (uint32_t)sealedpubkey_size,
+                 (sgx_sealed_data_t *)sealedpubkey)) != SGX_SUCCESS) {
+            print("\n[[TrustedApp]]: sgx_seal_data() failed !\n");
+            goto cleanup;
+        }
+    } else {
+        print(
+            "\n[[TrustedApp]]: Size allocated for sealedpubkey by untrusted "
+            "app "
+            "is less than the required size !\n");
+        ret = SGX_ERROR_INVALID_PARAMETER;
+        goto cleanup;
+    }
+
+    print(
+        "\n[[TrustedApp]]: Key pair generated and private & public keys were "
+        "sealed.\n");
     ret = SGX_SUCCESS;
 
 cleanup:

--- a/enclave/makefile
+++ b/enclave/makefile
@@ -20,7 +20,7 @@ all: ../interface/libenclave_stub_t.a enclave.signed.so
 
 ../interface/libenclave_stub_t.a: ../interface/enclave.edl
 
-enclave.unsigned.so: calcbuffsize.o keygen.o print.o sign.o
+enclave.unsigned.so: calcbuffsize.o keygen.o print.o sign.o quote.o
 
 enclave.signed.so: enclave.key.pem
 

--- a/enclave/print.c
+++ b/enclave/print.c
@@ -7,7 +7,6 @@
 #include <enclave_t.h>
 #include "enclave.h"
 
-void print(const char * const str)
-{
-  ocall_print_string(str);
-}
+void print(const char* const str) { ocall_print_string(str); }
+
+// void printint(const int num) { ocall_print_int(num); }

--- a/enclave/quote.c
+++ b/enclave/quote.c
@@ -1,0 +1,81 @@
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <enclave_t.h>
+#include "enclave.h"
+
+#include <sgx_quote.h>
+#include <sgx_tcrypto.h>
+#include <sgx_tseal.h>
+#include <sgx_uae_epid.h>
+#include <sgx_utils.h>
+
+/**
+ * This function unseals the sealed public key from app and then generates a
+ * quote with the public key (x & y coordinates, uncompressed) in the report
+ * data field.
+ *
+ * @param report             Input parameter for report.
+ * @param target_info        Input parameter for target info.
+ * @param sealed             Input parameter for sealed public key.
+ * @param sealed_size        Input parameter for size of sealed public key.
+ *
+ * @return                   SGX_SUCCESS (Error code = 0x0000) on success, some
+ *                           other appropriate sgx_status_t value upon failure.
+ */
+sgx_status_t ecall_unseal_and_quote(sgx_report_t *report,
+                                    sgx_target_info_t *target_info,
+                                    char *sealed, size_t sealed_size,
+                                    char *public_key, size_t public_key_size) {
+    sgx_status_t ret = SGX_ERROR_UNEXPECTED;
+
+    print("\nTrustedApp: Received the sealed public key.\n");
+
+    // Step 1: Calculate sealed/encrypted data length.
+    uint32_t unsealed_data_size =
+        sgx_get_encrypt_txt_len((const sgx_sealed_data_t *)sealed);
+    uint8_t *const unsealed_data =
+        (uint8_t *)malloc(unsealed_data_size);  // Check malloc return;
+    if (unsealed_data == NULL) {
+        print("\nTrustedApp: malloc(unsealed_data_size) failed !\n");
+        goto cleanup;
+    }
+
+    // Step 2: Unseal public key, and copy into report data
+    if ((ret = sgx_unseal_data((sgx_sealed_data_t *)sealed, NULL, NULL,
+                               unsealed_data, &unsealed_data_size)) !=
+        SGX_SUCCESS) {
+        print("\nTrustedApp: sgx_unseal_data() failed !\n");
+        goto cleanup;
+    }
+
+    // DEBUG - copy unsealed public key to public_key_buffer to print to stdout
+    // memcpy_s((uint8_t *)public_key, sizeof(public_key_size), &unsealed_data,
+    // unsealed_data_size);
+    memcpy((uint8_t *)public_key, unsealed_data, unsealed_data_size);
+
+    sgx_report_data_t report_data = {{0}};
+    memcpy((uint8_t *const) & report_data, unsealed_data, unsealed_data_size);
+    // memcpy(&report_data, unsealed_data, unsealed_data_size);
+
+    // BEGIN WIP --------------------------------------------
+    print("[[TrustedApp]]: Calling enclave to generate attestation report\n");
+    ret = sgx_create_report(target_info, &report_data, report);
+    // --------------------------------------------- END WIP
+
+    print(
+        "\nTrustedApp: Unsealed the sealed public key, generated a quote with "
+        "with this public key in the report data, and sent quote back\n");
+
+    // ret = SGX_SUCCESS;
+
+cleanup:
+    // Step 5: Release memory
+    if (unsealed_data != NULL) {
+        memset_s(unsealed_data, unsealed_data_size, 0, unsealed_data_size);
+        free(unsealed_data);
+    }
+
+    return ret;
+}

--- a/enclave/sign.c
+++ b/enclave/sign.c
@@ -12,15 +12,15 @@
 #include "enclave.h"
 
 #include <sgx_tcrypto.h>
-#include <sgx_utils.h>
 #include <sgx_tseal.h>
+#include <sgx_utils.h>
 
 /**
- * This function unseals the sealed data from app and then performs ECDSA signing on
- * this unsealed data.
+ * This function unseals the sealed data from app and then performs ECDSA
+ * signing on this unsealed data.
  *
- * @param msg                Input parameter for message to be signed. Message may
- *                           be some sensor data.
+ * @param msg                Input parameter for message to be signed. Message
+ * may be some sensor data.
  * @param msg_size           Input parameter for size of message.
  * @param sealed             Input parameter for sealed data.
  * @param sealed_size        Input parameter for size of sealed data.
@@ -31,58 +31,62 @@
  *                           other appropriate sgx_status_t value upon failure.
  */
 
-sgx_status_t ecall_unseal_and_sign(uint8_t *msg, uint32_t msg_size, char *sealed, size_t sealed_size, char *signature, size_t signature_size)
-{
-  sgx_status_t ret = SGX_ERROR_UNEXPECTED;
-  sgx_ecc_state_handle_t p_ecc_handle = NULL;
+sgx_status_t ecall_unseal_and_sign(uint8_t *msg, uint32_t msg_size,
+                                   char *sealed, size_t sealed_size,
+                                   char *signature, size_t signature_size) {
+    sgx_status_t ret = SGX_ERROR_UNEXPECTED;
+    sgx_ecc_state_handle_t p_ecc_handle = NULL;
 
-  print("\nTrustedApp: Received sensor data and the sealed private key.\n");
+    print("\nTrustedApp: Received sensor data and the sealed private key.\n");
 
-  // Step 1: Calculate sealed/encrypted data length.
-  uint32_t unsealed_data_size = sgx_get_encrypt_txt_len((const sgx_sealed_data_t *)sealed);
-  uint8_t * const unsealed_data = (uint8_t *)malloc(unsealed_data_size); // Check malloc return;
-  if (unsealed_data == NULL)
-  {
-    print("\nTrustedApp: malloc(unsealed_data_size) failed !\n");
-    goto cleanup;
-  }
+    // Step 1: Calculate sealed/encrypted data length.
+    uint32_t unsealed_data_size =
+        sgx_get_encrypt_txt_len((const sgx_sealed_data_t *)sealed);
+    uint8_t *const unsealed_data =
+        (uint8_t *)malloc(unsealed_data_size);  // Check malloc return;
+    if (unsealed_data == NULL) {
+        print("\nTrustedApp: malloc(unsealed_data_size) failed !\n");
+        goto cleanup;
+    }
 
-  // Step 2: Unseal data.
-  if ((ret = sgx_unseal_data((sgx_sealed_data_t *)sealed, NULL, NULL, unsealed_data, &unsealed_data_size)) != SGX_SUCCESS)
-  {
-    print("\nTrustedApp: sgx_unseal_data() failed !\n");
-    goto cleanup;
-  }
+    // Step 2: Unseal data.
+    if ((ret = sgx_unseal_data((sgx_sealed_data_t *)sealed, NULL, NULL,
+                               unsealed_data, &unsealed_data_size)) !=
+        SGX_SUCCESS) {
+        print("\nTrustedApp: sgx_unseal_data() failed !\n");
+        goto cleanup;
+    }
 
-  // Step 3: Open Context.
-  if ((ret = sgx_ecc256_open_context(&p_ecc_handle)) != SGX_SUCCESS)
-  {
-    print("\nTrustedApp: sgx_ecc256_open_context() failed !\n");
-    goto cleanup;
-  }
+    // Step 3: Open Context.
+    if ((ret = sgx_ecc256_open_context(&p_ecc_handle)) != SGX_SUCCESS) {
+        print("\nTrustedApp: sgx_ecc256_open_context() failed !\n");
+        goto cleanup;
+    }
 
-  // Step 4: Perform ECDSA Signing.
-  if ((ret = sgx_ecdsa_sign(msg, msg_size, (sgx_ec256_private_t *)unsealed_data, (sgx_ec256_signature_t *)signature, p_ecc_handle)) != SGX_SUCCESS)
-  {
-    print("\nTrustedApp: sgx_ecdsa_sign() failed !\n");
-    goto cleanup;
-  }
+    // Step 4: Perform ECDSA Signing.
+    if ((ret =
+             sgx_ecdsa_sign(msg, msg_size, (sgx_ec256_private_t *)unsealed_data,
+                            (sgx_ec256_signature_t *)signature,
+                            p_ecc_handle)) != SGX_SUCCESS) {
+        print("\nTrustedApp: sgx_ecdsa_sign() failed !\n");
+        goto cleanup;
+    }
 
-  print("\nTrustedApp: Unsealed the sealed private key, signed sensor data with this private key and then, sent the signature back.\n");
+    print(
+        "\nTrustedApp: Unsealed the sealed private key, signed sensor data "
+        "with this private key and then, sent the signature back.\n");
 
-  ret = SGX_SUCCESS;
+    ret = SGX_SUCCESS;
 
 cleanup:
-  // Step 5: Close Context, release memory
-  if (p_ecc_handle != NULL)
-  {
-    sgx_ecc256_close_context(p_ecc_handle);
-  }
-  if (unsealed_data != NULL)
-  {
-    memset_s(unsealed_data, unsealed_data_size, 0, unsealed_data_size);
-    free(unsealed_data);
-  }
+    // Step 5: Close Context, release memory
+    if (p_ecc_handle != NULL) {
+        sgx_ecc256_close_context(p_ecc_handle);
+    }
+    if (unsealed_data != NULL) {
+        memset_s(unsealed_data, unsealed_data_size, 0, unsealed_data_size);
+        free(unsealed_data);
+    }
 
-  return ret;
+    return ret;
 }

--- a/interface/enclave.edl
+++ b/interface/enclave.edl
@@ -6,18 +6,53 @@
 
 enclave
 {
-	include "sgx_report.h"
+	include "sgx_quote.h"
 
     trusted
     {
-        public sgx_status_t ecall_key_gen_and_seal([out, size=pubkey_size] char *pubkey, size_t pubkey_size, [out, size=sealedprivkey_size] char *sealedprivkey, size_t sealedprivkey_size);
-        public sgx_status_t ecall_calc_buffer_sizes([out] size_t* epubkey_size, [out] size_t* esealedprivkey_size, [out] size_t* esignature_size);
-        public sgx_status_t ecall_unseal_and_sign([in, size=msg_size] uint8_t * msg, uint32_t msg_size, [in, size=sealed_size]char *sealed, size_t sealed_size, [out, size=signature_size] char* signature, size_t signature_size);
-		public sgx_status_t ecall_report_gen([out] sgx_report_t *report, [in] sgx_target_info_t *target_info, sgx_report_data_t report_data);
+        public sgx_status_t ecall_key_gen_and_seal(
+            [out, size=pubkey_size] char *pubkey,
+            size_t pubkey_size,
+            [out, size=sealedprivkey_size] char *sealedprivkey,
+            size_t sealedprivkey_size);
+
+        public sgx_status_t ecall_key_gen_and_seal_all(
+            [out, size=sealedpubkey_size] char *sealedpubkey,
+            size_t sealedpubkey_size,
+            [out, size=sealedprivkey_size] char *sealedprivkey,
+            size_t sealedprivkey_size);
+
+        public sgx_status_t ecall_calc_buffer_sizes(
+            [out] size_t* epubkey_size,
+            [out] size_t* esealedpubkey_size,
+            [out] size_t* esealedprivkey_size,
+            [out] size_t* esignature_size);
+
+        public sgx_status_t ecall_unseal_and_sign(
+            [in, size=msg_size] uint8_t * msg,
+            uint32_t msg_size,
+            [in, size=sealed_size]char *sealed,
+            size_t sealed_size,
+            [out, size=signature_size] char* signature,
+            size_t signature_size);
+        
+        public sgx_status_t ecall_unseal_and_quote(
+            [out] sgx_report_t *report,
+            [in] sgx_target_info_t *target_info,
+            [in, size=sealed_size]char *sealed,
+            size_t sealed_size,
+            [out, size=public_key_size] char *public_key,
+            size_t public_key_size);
+
+		public sgx_status_t ecall_report_gen(
+            [out] sgx_report_t *report,
+            [in] sgx_target_info_t *target_info,
+            sgx_report_data_t report_data);
     };
 
     untrusted
     {
         void ocall_print_string([in, string] const char *str);
+        //void ocall_print_int([in, int] const int num);
     };
 };

--- a/run_demo_sgxra.sh
+++ b/run_demo_sgxra.sh
@@ -1,0 +1,43 @@
+#!/bin/sh -e
+#                                               -*- Makefile -*-
+#
+# Copyright (C) 2011-2019 Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+
+test -d demo_sgx || mkdir demo_sgx
+cd demo_sgx
+
+# Clean up from previous runs
+rm -f sealedprivkey.bin sealedpubkey.bin secp256r1.pem Sensor_Data.signature quote.bin
+
+echo "Provisioning private elliptic curve key:"
+# Generate the keypair (both private & public keys are sealed to enclave)
+#../app/app --keygen --enclave-path `pwd`/../enclave/enclave.signed.so --statefile sealeddata.bin --public-key secp256r1.pem
+../app/app --keygen \
+    --enclave-path `pwd`/../enclave/enclave.signed.so \
+    --sealedprivkey sealedprivkey.bin \
+    --sealedpubkey sealedpubkey.bin \
+    --public-key secp256r1.pem
+echo "Key provisoning completed.\n"
+
+echo "\nGenerating quote for remote attestation:"
+# Generate the quote
+../app/app --quote \
+    --enclave-path `pwd`/../enclave/enclave.signed.so \
+    --sealedpubkey sealedpubkey.bin \
+    --quotefile quote.bin
+echo "Quote generation completed.\n"
+
+echo "\nSigning sensor data:"
+../app/app --sign \
+    --enclave-path `pwd`/../enclave/enclave.signed.so \
+    --sealedprivkey sealedprivkey.bin \
+    --signature Sensor_Data.signature ../Sensor_Data
+echo "Sensor data signed.\n"
+
+echo "\nVerifying quote and signature:"
+cd ..
+python verify.py

--- a/run_keygen.sh
+++ b/run_keygen.sh
@@ -1,0 +1,23 @@
+#!/bin/sh -e
+#                                               -*- Makefile -*-
+#
+# Copyright (C) 2011-2019 Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+
+test -d demo_sgx || mkdir demo_sgx
+cd demo_sgx
+
+# Clean up from previous runs
+rm -f sealedprivkey.bin sealedpubkey.bin secp256r1.pem Sensor_Data.signature
+
+echo "Provisioning private elliptic curve key:"
+# Generate the keypair (both private & public keys are sealed to enclave)
+#../app/app --keygen --enclave-path `pwd`/../enclave/enclave.signed.so --statefile sealeddata.bin --public-key secp256r1.pem
+../app/app --keygen --enclave-path `pwd`/../enclave/enclave.signed.so \
+    --sealedprivkey sealedprivkey.bin \
+    --sealedpubkey sealedpubkey.bin \
+    --public-key secp256r1.pem
+echo "Key provisoning completed.\n"

--- a/run_quote.sh
+++ b/run_quote.sh
@@ -1,0 +1,45 @@
+#!/bin/sh -e
+#                                               -*- Makefile -*-
+#
+# Copyright (C) 2011-2019 Intel Corporation
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+
+test -d demo_sgx || mkdir demo_sgx
+cd demo_sgx
+
+# Clean up from previous runs
+rm -f sealedprivkey.bin sealedpubkey.bin secp256r1.pem Sensor_Data.signature quote.bin
+
+echo "Provisioning private elliptic curve key:"
+# Generate the keypair (both private & public keys are sealed to enclave)
+#../app/app --keygen --enclave-path `pwd`/../enclave/enclave.signed.so --statefile sealeddata.bin --public-key secp256r1.pem
+../app/app --keygen \
+    --enclave-path `pwd`/../enclave/enclave.signed.so \
+    --sealedprivkey sealedprivkey.bin \
+    --sealedpubkey sealedpubkey.bin \
+    --public-key secp256r1.pem
+echo "Key provisoning completed.\n"
+
+echo "\nGenerating quote for remote attestation:"
+# Generate the quote
+../app/app --quote \
+    --enclave-path `pwd`/../enclave/enclave.signed.so \
+    --sealedpubkey sealedpubkey.bin \
+    --quotefile quote.bin
+echo "Quote generation completed.\n"
+
+echo "\nVerify MRENCLAVE with source code:"
+
+#echo "\nSigning sensor data:"
+#../app/app --sign \
+#    --enclave-path `pwd`/../enclave/enclave.signed.so \
+#    --sealedprivkey sealedprivkey.bin \
+#    --signature Sensor_Data.signature ../Sensor_Data
+#echo "Sensor data signed.\n"
+#
+#echo "\nVerifying signature:"
+#cd ..
+#python verifysig.py

--- a/verify.py
+++ b/verify.py
@@ -1,0 +1,109 @@
+import base64
+import json
+import os
+import pprint
+import sys
+
+import requests
+
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives import hashes
+
+
+def little2big_endian(b):
+    return swap_endians(b)
+
+
+def swap_endians(b, *, length=32, from_byteorder="little", to_byteorder="big"):
+    return int.from_bytes(b, from_byteorder).to_bytes(length, "big")
+
+
+##############################################################################
+#                                                                            #
+#                          Verify quote with IAS                             #
+#                                                                            #
+##############################################################################
+print("Reading quote from file ...")
+with open("demo_sgx/quote.bin", "rb") as f:
+    quote_bytes = f.read()
+
+quote_b64 = base64.b64encode(quote_bytes)
+quote_dict = {"isvEnclaveQuote": quote_b64.decode()}
+
+# send the quote for verification
+# To send the quote over to Intel, you need your API primary subscription key,
+# which you should have set as an environment variable before starting the
+# container. (See the prerequisite section if needed.)
+url = "https://api.trustedservices.intel.com/sgx/dev/attestation/v4/report"
+
+headers = {
+    "Content-Type": "application/json",
+    "Ocp-Apim-Subscription-Key": os.environ["IAS_PRIMARY_KEY"],
+}
+
+print("Sending quote to Intel's Attestation Service for verification ...")
+res = requests.post(url, json=quote_dict, headers=headers)
+
+if res.ok:
+    print("Attestation verification succeeded!\n")
+else:
+    sys.exit(
+        "Attestatin verification failed, with status "
+        f"{res.status_code} and reason {res.reason}\n"
+    )
+
+print("IAS response is: ")
+pprint.pprint(res.json())
+
+ias_report = {"body": res.json(), "headers": dict(res.headers)}
+
+with open("demo_sgx/ias_report.json", "w") as f:
+    json.dump(ias_report, f)
+
+import auditee  # noqa
+
+match = auditee.verify_mrenclave(
+    "/usr/src/sgxiot/",
+    "/usr/src/sgxiot/enclave/enclave.signed.so",
+    ias_report="/usr/src/sgxiot/demo_sgx/ias_report.json",
+)
+
+if not match:
+    sys.exit(
+        "MRENCLAVE of remote attestation report does not match trusted source code."
+    )
+
+
+##############################################################################
+#                                                                            #
+#                 Extract Pulic Key from attestation report                  #
+#                                                                            #
+##############################################################################
+print("\nExtracting public key from IAS report ...")
+quote_body = res.json()["isvEnclaveQuoteBody"]
+report_data = base64.b64decode(quote_body)[368:432]
+x_little = report_data[:32]
+y_little = report_data[32:]
+x = little2big_endian(x_little)
+y = little2big_endian(y_little)
+point = b"\x04" + x + y
+pubkey = ec.EllipticCurvePublicKey.from_encoded_point(curve=ec.SECP256R1(), data=point)
+
+
+##############################################################################
+#                                                                            #
+#                          Verify Signature                                  #
+#                                                                            #
+##############################################################################
+with open("demo_sgx/Sensor_Data.signature", "rb") as f:
+    signature = f.read()
+
+with open("Sensor_Data") as f:
+    sensor_data = f.read()
+
+print(f"\nVerifying signature {signature.hex()} for sensor data:\n{sensor_data}\n")
+pubkey.verify(
+    signature, sensor_data.encode(), signature_algorithm=ec.ECDSA(hashes.SHA256()),
+)
+
+print("Signature verification successful!")

--- a/verifysig.py
+++ b/verifysig.py
@@ -1,0 +1,101 @@
+import base64
+import json
+import os
+import pprint
+
+import requests
+
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives import hashes
+
+
+def little2big_endian(b):
+    return swap_endians(b)
+
+
+def swap_endians(b, *, length=32, from_byteorder="little", to_byteorder="big"):
+    return int.from_bytes(b, from_byteorder).to_bytes(length, "big")
+
+
+##############################################################################
+#                                                                            #
+#                          Verify quote with IAS                             #
+#                                                                            #
+##############################################################################
+print("Reading quote from file ...")
+with open("demo_sgx/quote.bin", "rb") as f:
+    quote_bytes = f.read()
+
+quote_b64 = base64.b64encode(quote_bytes)
+quote_dict = {"isvEnclaveQuote": quote_b64.decode()}
+
+# send the quote for verification
+# To send the quote over to Intel, you need your API primary subscription key,
+# which you should have set as an environment variable before starting the
+# container. (See the prerequisite section if needed.)
+url = "https://api.trustedservices.intel.com/sgx/dev/attestation/v4/report"
+
+headers = {
+    "Content-Type": "application/json",
+    "Ocp-Apim-Subscription-Key": os.environ["IAS_PRIMARY_KEY"],
+}
+
+print("Sending quote to Intel's Attestation Service for verification ...")
+res = requests.post(url, json=quote_dict, headers=headers)
+
+if res.ok:
+    print("Attestation verification succeeded!\n")
+else:
+    print(f"Attestatin failed, with status {res.status_code} and reason {res.reason}\n")
+    exit(1)
+
+print("IAS response is: ")
+pprint.pprint(res.json())
+
+ias_report = {"body": res.json(), "headers": dict(res.headers)}
+
+with open("demo_sgx/ias_report.json", "w") as f:
+    json.dump(ias_report, f)
+
+import auditee  # noqa
+
+auditee.verify_mrenclave(
+    "/usr/src/sgxiot/",
+    "/usr/src/sgxiot/enclave/enclave.signed.so",
+    ias_report="/usr/src/sgxiot/demo_sgx/ias_report.json",
+)
+
+
+##############################################################################
+#                                                                            #
+#                 Extract Pulic Key from attestation report                  #
+#                                                                            #
+##############################################################################
+print("\nExtracting public key from IAS report ...")
+quote_body = res.json()["isvEnclaveQuoteBody"]
+report_data = base64.b64decode(quote_body)[368:432]
+x_little = report_data[:32]
+y_little = report_data[32:]
+x = little2big_endian(x_little)
+y = little2big_endian(y_little)
+point = b"\x04" + x + y
+pubkey = ec.EllipticCurvePublicKey.from_encoded_point(curve=ec.SECP256R1(), data=point)
+
+
+##############################################################################
+#                                                                            #
+#                          Verify Signature                                  #
+#                                                                            #
+##############################################################################
+with open("demo_sgx/Sensor_Data.signature", "rb") as f:
+    signature = f.read()
+
+with open("Sensor_Data") as f:
+    sensor_data = f.read()
+
+print(f"\nVerifying signature {signature.hex()} for sensor data:\n{sensor_data}\n")
+pubkey.verify(
+    signature, sensor_data.encode(), signature_algorithm=ec.ECDSA(hashes.SHA256()),
+)
+
+print("Signature verification successful!")


### PR DESCRIPTION
The demo performs the following steps:

SERVER
* [server|trusted] Generate a keypair
* [server|trusted] Seal both the private and public keys
* [server|trusted] Unseal the public key to put it in report data
* [server|trusted] Create attestation report with public key in repprt
  data
* [server|trusted] Get quote from report
* [server|untrusted] Write quote to file
* [server|trusted] Unseal private key and sign sensor data

CLIENT
* [client] Send quote to Intel
* [client] Verify that report is valid
* [client] Verify MRENCLAVE in report with trusted source code, using
  auditee to reproduce the build
* [client] Extract public key out of report
* [client] Verify signature